### PR TITLE
[GEN-158] Log a warning on http response write error

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -96,7 +96,7 @@ func (server *RESTServer) CompleteRequest(start time.Time, context *Context) {
 
 	context.Response.WriteHeader(context.responseStatus)
 	_, err := context.Response.Write(b)
-	log.Error(err)
+	log.Warn(err)
 }
 
 func (server *RESTServer) completeRequestJSON(context *Context) {
@@ -117,7 +117,8 @@ func (server *RESTServer) completeRequestJSON(context *Context) {
 		}
 	}
 	context.Response.WriteHeader(context.responseStatus)
-	context.Response.Write(b)
+	_, err := context.Response.Write(b)
+	log.Warn(err)
 }
 
 // ListenAndServe starts a http server listening on the address specified


### PR DESCRIPTION
This will deescalate the following errors that have come through the logs lately:

`write tcp 10.22.10.145:8080->10.22.10.124:41064: write: connection reset by peer`

`write tcp 10.0.11.219:8080->10.0.11.77:40910: write: broken pipe`